### PR TITLE
set background-position to show rubio

### DIFF
--- a/css/congress.css
+++ b/css/congress.css
@@ -61,7 +61,7 @@ body {
  
    display: block;
    width: 200px;
-    height: 600px;
+    height: 300px;
     overflow: hidden;
     white-space: nowrap;
     background: url("../images/presidents.png");

--- a/css/congress.css
+++ b/css/congress.css
@@ -41,6 +41,7 @@ body {
     overflow: hidden;
     white-space: nowrap;
     background: url("../images/presidents.png");
+    background-position: 0 0;
 }
 
 .col-2:hover {
@@ -64,9 +65,12 @@ body {
     overflow: hidden;
     white-space: nowrap;
     background: url("../images/presidents.png");
+    background-position: 0 -300px;
 }
 
-
+.col-3:hover {
+    background-position: -400px -300px;
+  }
 
 
 


### PR DESCRIPTION
This  adds background position to show Rubio. background-position takes two arguments the first is the horizontal position the second is the vertical position.
